### PR TITLE
Update to Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY argbash-templates/* /work/
 RUN ./build.sh
 
 # Create base for final image
-FROM anapsix/alpine-java:8_jdk as base
+FROM adoptopenjdk/openjdk11:alpine as base
 LABEL maintainer=oconnormi
 LABEL org.codice.application.type=ddf
 
@@ -13,7 +13,7 @@ ENV ENTRYPOINT_HOME=/opt/entrypoint
 
 RUN mkdir -p $ENTRYPOINT_HOME
 
-RUN apk add --no-cache curl openssl gettext
+RUN apk add --no-cache curl openssl gettext bash
 RUN  curl -L https://github.com/oconnormi/props/releases/download/v0.2.0/props_linux_amd64 -o /usr/local/bin/props \
     && chmod 755 /usr/local/bin/props
 RUN curl -LsSk https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/local/bin/jq \

--- a/entrypoint/global_env.sh
+++ b/entrypoint/global_env.sh
@@ -87,7 +87,7 @@ _client="${_app_bin}/client -r ${_karaf_client_retries} -d ${_karaf_client_delay
 ###### Readiness Check Settings #######
 _experimental_checks_enabled=${EXPERIMENTAL_READINESS_CHECKS_ENABLED:=false}
 # The following bundles are excluded from the legacy 'lna' based ready check
-_legacy_wfr_exclusions=${READINESS_EXCLUSIONS:="Apache Karaf :: Features :: Extension, Hosts|DDF :: Platform :: OSGi :: Conditions, Hosts|Apache Karaf :: Shell :: Console, Hosts|DDF :: Platform :: PaxWeb :: Jetty Config, Hosts|JLine JANSI Terminal, Hosts|Apache Aries Blueprint Core Compatiblity Fragment Bundle, Hosts"}
+_legacy_wfr_exclusions=${READINESS_EXCLUSIONS:="Apache Karaf :: Features :: Extension, Hosts|DDF :: Platform :: OSGi :: Conditions, Hosts|Apache Karaf :: Shell :: Console, Hosts|DDF :: Platform :: PaxWeb :: Jetty Config, Hosts|JLine JANSI Terminal, Hosts|Apache Aries Blueprint Core Compatiblity Fragment Bundle, Hosts|camel-caffeine-lrucache, Hosts"}
 
 ###### Functions ############
 


### PR DESCRIPTION
* Updated to Alpine with Java 11.
* Added `camel-caffeine-lrucache` to the legacy wfr exclusions.
