### PR TITLE
Prepare to Push 2.27-alpine tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
   stages {
     stage('Build Images') {
       steps {
+	    dockerd{}
         sh 'make image'
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,6 @@ pipeline {
     */
     cron(BRANCH_NAME == "master" ? "H H(4-6) * * *" : "")
   }
-  // environment { PATH="${tool 'docker-latest'}/bin:$PATH" }
   stages {
     stage('Build Images') {
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 @Library('github.com/connexta/cx-pipeline-library@master') _
 pipeline {
-  agent { label 'linux-docker-small' }
+  agent { label 'linux-small' }
   options {
     buildDiscarder(logRotator(numToKeepStr:'25'))
     disableConcurrentBuilds()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
+@Library('github.com/connexta/cx-pipeline-library@master') _
 pipeline {
   agent { label 'linux-docker-small' }
   options {
@@ -12,7 +13,7 @@ pipeline {
     */
     cron(BRANCH_NAME == "master" ? "H H(4-6) * * *" : "")
   }
-  environment { PATH="${tool 'docker-latest'}/bin:$PATH" }
+  // environment { PATH="${tool 'docker-latest'}/bin:$PATH" }
   stages {
     stage('Build Images') {
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,13 +6,6 @@ pipeline {
     disableConcurrentBuilds()
     timestamps()
   }
-  triggers {
-    /*
-      Restrict nightly builds to master branch
-      Note: The BRANCH_NAME will only work with a multi-branch job using the github-branch-source
-    */
-    cron(BRANCH_NAME == "master" ? "H H(4-6) * * *" : "")
-  }
   stages {
     stage('Build Images') {
       steps {

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ IMAGE_NAME:=codice/ddf-base
 GIT_SHA:=$(shell git rev-parse HEAD)
 MASTER_SHA:=$(shell git show-ref -s refs/heads/master)
 ifneq (${MASTER_SHA}, ${GIT_SHA})
-	IMAGE_VERSION=${GIT_SHA}
+    IMAGE_VERSION=2.27-alpine 	
+#   IMAGE_VERSION=${GIT_SHA}
 else
 	IMAGE_VERSION=latest
 endif

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,8 @@ IMAGE_NAME:=codice/ddf-base
 
 GIT_SHA:=$(shell git rev-parse HEAD)
 MASTER_SHA:=$(shell git show-ref -s refs/heads/master)
-ifneq (${MASTER_SHA}, ${GIT_SHA})
-    IMAGE_VERSION=2.27-alpine 	
-#   IMAGE_VERSION=${GIT_SHA}
-else
-	IMAGE_VERSION=latest
-endif
+IMAGE_VERSION=2.27-alpine 	
+
 # Compute Build Tag
 BUILD_TAG=$(IMAGE_NAME):$(IMAGE_VERSION)
 


### PR DESCRIPTION
## What does this PR do?
change agent from docker-linux-small to linux-small
Added a shared library to call dockerd
Started dockerd in the 'Build Images' stage
Hard code tag 2.27-alpine in Makefile

## Who are reviewers
@LinkMJB 
@frnkshin 