### PR TITLE
Pin JDK base images by digest; produce JDK 17 (3.x) and JDK 21 (4.x) variants

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -9,6 +9,22 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - jdk: "17"
+            java_base: "azul/zulu-openjdk-alpine:17.0.19-17.66@sha256:7710ea650d0d685d6c9525c21ea89c37cf820393ab54bcc0eedbe5cbb85a09d8"
+            tags: |
+              codice/ddf-base:3.1
+              codice/ddf-base:3.1-jdk17
+              codice/ddf-base:jdk17-latest
+          - jdk: "21"
+            java_base: "azul/zulu-openjdk-alpine:21.0.11-21.50@sha256:50016a4365837ca6f36995f684545799c53d99cd762575eb63c0701d4fb79d00"
+            tags: |
+              codice/ddf-base:4.0
+              codice/ddf-base:4.0-jdk21
+              codice/ddf-base:jdk21-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -29,18 +45,17 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push multi-arch images
+      - name: Build and push multi-arch image (JDK ${{ matrix.jdk }})
         uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            codice/ddf-base:3.0
-            codice/ddf-base:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          build-args: |
+            JAVA_BASE=${{ matrix.java_base }}
+          tags: ${{ matrix.tags }}
+          cache-from: type=gha,scope=jdk${{ matrix.jdk }}
+          cache-to: type=gha,mode=max,scope=jdk${{ matrix.jdk }}
 
-      - name: Inspect multi-arch manifest
-        run: docker buildx imagetools inspect codice/ddf-base:3.0
-
+      - name: Inspect multi-arch manifest (JDK ${{ matrix.jdk }})
+        run: docker buildx imagetools inspect codice/ddf-base:jdk${{ matrix.jdk }}-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,13 +1,16 @@
 name: Build and Push Multi-Arch Images
 
 on:
+  pull_request:
+    branches:
+      - master
   push:
     branches:
       - master
   workflow_dispatch:
 
 jobs:
-  build-and-push:
+  build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -40,22 +43,37 @@ jobs:
           install: true
 
       - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push multi-arch image (JDK ${{ matrix.jdk }})
+      - name: Build multi-arch image (JDK ${{ matrix.jdk }})
         uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
+          load: false
           build-args: |
             JAVA_BASE=${{ matrix.java_base }}
           tags: ${{ matrix.tags }}
           cache-from: type=gha,scope=jdk${{ matrix.jdk }}
           cache-to: type=gha,mode=max,scope=jdk${{ matrix.jdk }}
 
+      - name: Smoke-test image (JDK ${{ matrix.jdk }})
+        run: |
+          # Reload the locally-built image for one platform so we can run it.
+          docker buildx build \
+            --platform linux/amd64 \
+            --build-arg JAVA_BASE='${{ matrix.java_base }}' \
+            --load \
+            -t ddf-base-smoke:${{ matrix.jdk }} .
+          actual=$(docker run --rm --entrypoint java ddf-base-smoke:${{ matrix.jdk }} -version 2>&1 | head -1)
+          echo "Reported: $actual"
+          echo "$actual" | grep -q '"${{ matrix.jdk }}\.' || { echo "FAIL: expected JDK ${{ matrix.jdk }}, got $actual"; exit 1; }
+
       - name: Inspect multi-arch manifest (JDK ${{ matrix.jdk }})
+        if: github.event_name != 'pull_request'
         run: docker buildx imagetools inspect codice/ddf-base:jdk${{ matrix.jdk }}-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
+# Image refs are pinned by digest for reproducible builds.
+# Override JAVA_BASE at build time to produce JDK-specific variants
+# (default: JDK 17 for the 2.30.x / Alliance 1.17.x train; pass JDK 21 base for the 2.31+ train).
+ARG ARGBASH_IMAGE=matejak/argbash:2.7.1-1@sha256:37e6805e02a940229073654ba3249cfb92392a465c3d9b329008926ad0133e3f
+ARG JAVA_BASE=azul/zulu-openjdk-alpine:17.0.19-17.66@sha256:7710ea650d0d685d6c9525c21ea89c37cf820393ab54bcc0eedbe5cbb85a09d8
+
 # Generate commands from argbash templates
-FROM --platform=$BUILDPLATFORM matejak/argbash:2.7.1-1 AS argbash
+FROM --platform=$BUILDPLATFORM ${ARGBASH_IMAGE} AS argbash
 # Copy all templates including vendored create-cdm.m4 (eliminates external dependency)
 COPY argbash-templates/* /work/
 RUN ./build.sh
 
-# Create base for final image
-FROM azul/zulu-openjdk-alpine:17-latest AS base
-LABEL maintainer=oconnormi
+# Create base for final image.
+FROM ${JAVA_BASE} AS base
+LABEL maintainer=codice
 LABEL org.codice.application.type=ddf
 
 ENV ENTRYPOINT_HOME=/opt/entrypoint

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ENV APP_LOG=<log_file>
 # Install application
 ```
 ## Features
-  * Oracle JDK8
+  * Azul Zulu OpenJDK 17 (tag `3.x`) or 21 (tag `4.x`); both pinned by digest. Pick the variant that matches your downstream DDF train.
   * [jq](https://stedolan.github.io/jq/) for processing json
   * curl
   * [props](https://github.com/oconnormi/props) tool for modifying properties files


### PR DESCRIPTION
## Summary

- Pins `azul/zulu-openjdk-alpine` and `matejak/argbash` by image digest via `ARG` defaults; downstream rebuilds are now bit-for-bit reproducible.
- Converts CI to a matrix that produces **two** image trains from the same Dockerfile:
  - **JDK 17** (Zulu `17.0.19-17.66`): published as `codice/ddf-base:3.1`, `:3.1-jdk17`, `:jdk17-latest` — for DDF `2.30.x` maintenance + Alliance `1.17.x`.
  - **JDK 21** (Zulu `21.0.11-21.50`): published as `codice/ddf-base:4.0`, `:4.0-jdk21`, `:jdk21-latest` — for DDF master (post codice/ddf#6999 → `2.31.0` on JDK 21).
- Drops the floating `codice/ddf-base:latest` tag. Consumers must pick a JDK-pinned tag; this avoids the regression class that produced an unbootable Alliance 1.17.4 (Java 8 image + Java 17 setenv).
- README features section: "Oracle JDK8" → accurate JDK 17/21 description.
- Changes `LABEL maintainer` from `oconnormi` to `codice`.

## Test plan

- [x] `docker build` for JDK 17 variant succeeds locally; `java -version` reports `Zulu17.66+19 / 17.0.19`.
- [x] `docker build --build-arg JAVA_BASE=<zulu-21-digest>` succeeds; `java -version` reports `Zulu21.50+19 / 21.0.11`.
- [ ] CI matrix workflow runs green on this PR.
- [ ] Sanity check by a downstream consumer build (`codice/alliance` Docker module) after merge — separate PR will pin `<docker.ddf.base.version>` to `3.1@sha256:<resulting-digest>`.

## Follow-ups (not in this PR)

- `codice/alliance` PR to pin `<docker.ddf.base.version>` to the new JDK-17 digest.
- `codice/ddf` PR to do the same in its Docker module (and switch to JDK 21 tag whenever codice/ddf#6999 lands).